### PR TITLE
[fix] Fix service cleanup

### DIFF
--- a/back-end/src/templates/ambassador/inference-engine-service.yaml.j2
+++ b/back-end/src/templates/ambassador/inference-engine-service.yaml.j2
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ engine_name }}
+  labels:
+    aas-ie-service: "true"
 spec:
   selector:
     app: {{ engine_name }}

--- a/back-end/src/templates/knative/inference-engine-knative-service.yaml.j2
+++ b/back-end/src/templates/knative/inference-engine-knative-service.yaml.j2
@@ -2,6 +2,8 @@ apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: {{ engine_name }}
+  labels:
+    aas-ie-service: "true"
 spec:
   template:
     spec:


### PR DESCRIPTION
### Changes:

1. Edited service cleanup task to delete services marked with a label so that services not in database can be cleared as well

### Rationale:

These changes were done because in the case where a service is not in the database, the service cleanup will not work properly. To avoid deleting non ai app store related services accidently, we check specifically for services with a certain label.