### PR TITLE
Add a if check to fix 'NoneType object has no attribute connector.' error

### DIFF
--- a/back-end/src/routers/models.py
+++ b/back-end/src/routers/models.py
@@ -397,12 +397,13 @@ async def create_model_card_metadata(
     # Sanitize html
     card.markdown = await preprocess_html_post(card.markdown)
     card.performance = await preprocess_html_post(card.performance)
-    if card.experiment.connector != "" and card.experiment.connector is not None:
-        card.experiment.output_url = (
-            Experiment.from_connector(card.experiment.connector)
-            .get(exp_id=card.experiment.experiment_id)
-            .output_url
-        )
+    if card.experiment:
+        if card.experiment.connector != "" and card.experiment.connector is not None:
+            card.experiment.output_url = (
+                Experiment.from_connector(card.experiment.connector)
+                .get(exp_id=card.experiment.experiment_id)
+                .output_url
+            )
     card_dict: dict = jsonable_encoder(
         ModelCardModelDB(
             **card.dict(),


### PR DESCRIPTION
### Changes:
1. Added a check to see if experiment-id is None to prevent 'NoneType object has no attribute connector' error being thrown. (Resolves #82) 

### Rationale:
These changes were done because experiment-id is optional for end-user to input when creating a model card. Without this change, ai-appstore's backend will throw error "NoneType object has no attribute connector" when user did not enter experiment-id before creating model card.