### PR TITLE
Fix/enable rootless for frontend

### DIFF
--- a/front-end/Dockerfile
+++ b/front-end/Dockerfile
@@ -9,7 +9,7 @@ RUN quasar build
 
 # FROM nginx:stable as production-stage
 # COPY --from=build-stage /app/dist /user/share/nginx/html
-EXPOSE 80
+EXPOSE 8081
 # CMD ["nginx", "-g", "daemon off;"]
 ENTRYPOINT [ "sh", "entrypoint.sh" ]
-CMD ["quasar", "serve", "dist/spa", "-p", "80", "--history"]
+CMD ["quasar", "serve", "dist/spa", "-p", "8081", "--history"]

--- a/k8s/charts/aas-backend/templates/serviceaccount-rbac.yaml
+++ b/k8s/charts/aas-backend/templates/serviceaccount-rbac.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "aas-backend.serviceAccountName" . }}-role
-  namespace: ai-appstore
+  namespace: {{ .Release.Namespace }}
 rules:
   # to allow manage a deployment in APIGroup "apps"
   - apiGroups:
@@ -33,13 +33,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "aas-backend.serviceAccountName" . }}-role-binding
-  namespace: ai-appstore
+  namespace: {{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "aas-backend.serviceAccountName" . }}
-    namespace: ai-appstore
+    namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ include "aas-backend.serviceAccountName" . }}-role
-  namespace: ai-appstore
+  namespace: {{ .Release.Namespace }}

--- a/k8s/charts/aas-backend/templates/serviceaccount.yaml
+++ b/k8s/charts/aas-backend/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "aas-backend.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "aas-backend.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/k8s/charts/aas-frontend/templates/deployment.yaml
+++ b/k8s/charts/aas-frontend/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: 8081
               protocol: TCP
           env:
             - name: VUE_APP_BACKEND_URL

--- a/k8s/charts/aas-frontend/templates/serviceaccount.yaml
+++ b/k8s/charts/aas-frontend/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "aas-frontend.serviceAccountName" . }}
+  namespace: ai-appstore
   labels:
     {{- include "aas-frontend.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/k8s/charts/aas-frontend/templates/serviceaccount.yaml
+++ b/k8s/charts/aas-frontend/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "aas-frontend.serviceAccountName" . }}
-  namespace: ai-appstore
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "aas-frontend.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}


### PR DESCRIPTION
### Changes:

1. Changed front end port number from 80 to 8081 to enable front end pod to run without root access.
2. Refactor to get namespace using variable instead of hard coding.
 
### Rationale:

These changes were done because front end pod should not require root access in order to run. 