### PR TITLE
Fix / Update chart and app versions after making AAS openshift-compatible

### DIFF
--- a/k8s/charts/aas-backend/Chart.yaml
+++ b/k8s/charts/aas-backend/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.0.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.10"
+appVersion: "1.0.11"
 
 maintainers:
   - name: Mathias Ho


### PR DESCRIPTION
### Changes:

1. Update aas-backend's Chart and App versions to 1.0.11.
