### PR TITLE
Add release.yaml to enable release notes on Github

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,19 @@
+changelog:
+  exclude:
+    labels:
+      - good first issue
+      - duplicate
+      - help wanted
+      - invalid
+      - wontfix
+      - question
+  categories:
+    - title: 🎉 New Features 
+      labels:
+        - enhancement
+    - title: 🛠 Bug Fixes
+      labels:
+        - bug
+    - title: 👍 Other Changes
+      labels:
+        - "*"

--- a/k8s/charts/aas-backend/Chart.yaml
+++ b/k8s/charts/aas-backend/Chart.yaml
@@ -21,7 +21,7 @@ version: 1.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.1.0"
+appVersion: "1.2.0"
 
 maintainers:
   - name: Mathias Ho

--- a/k8s/charts/aas-frontend/Chart.yaml
+++ b/k8s/charts/aas-frontend/Chart.yaml
@@ -21,7 +21,7 @@ version: 1.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.1.0"
+appVersion: "1.2.0"
 
 maintainers:
   - name: Mathias Ho


### PR DESCRIPTION
### Changes:

1. Added release.yaml to enable release notes

### Rationale:

These changes were done to showcase releases we made on Github.